### PR TITLE
Drop interface from generated proxies

### DIFF
--- a/src/AbstractGeneratedProxy.php
+++ b/src/AbstractGeneratedProxy.php
@@ -26,14 +26,13 @@ abstract class AbstractGeneratedProxy
      *
      * @return mixed
      */
-    final protected function proxyCallToMainThread(string $interface, string $method, array $args)
+    final protected function proxyCallToMainThread(string $method, array $args)
     {
         $input = new Channel(1);
         $call  = new Call(
             $input,
             $this->hash,
             spl_object_hash($this),
-            $interface,
             $method,
             $args,
         );
@@ -44,10 +43,10 @@ abstract class AbstractGeneratedProxy
         return $result;
     }
 
-    final protected function notifyMainThreadAboutDestruction(string $interface): void
+    final protected function notifyMainThreadAboutDestruction(): void
     {
         try {
-            $this->out->send(new Destruct($this->hash, spl_object_hash($this), $interface));
+            $this->out->send(new Destruct($this->hash, spl_object_hash($this)));
         } catch (Channel\Error\Closed $closed) {
             // @ignoreException
         }

--- a/src/Composer/InterfaceProxier.php
+++ b/src/Composer/InterfaceProxier.php
@@ -145,11 +145,6 @@ final class InterfaceProxier
                 new Node\Expr\MethodCall(
                     new Node\Expr\Variable('this'),
                     'notifyMainThreadAboutDestruction',
-                    [
-                        new Node\Arg(
-                            new Node\Scalar\String_($this->interfaceName),
-                        ),
-                    ],
                 )
             ),
         )->makePublic()->makeFinal()->getNode();
@@ -187,9 +182,6 @@ final class InterfaceProxier
             new Node\Expr\Variable('this'),
             'proxyCallToMainThread',
             [
-                new Node\Arg(
-                    new Node\Scalar\String_($this->interfaceName),
-                ),
                 new Node\Arg(
                     new Node\Expr\ConstFetch(
                         new Node\Name('__FUNCTION__'),

--- a/src/Message/Call.php
+++ b/src/Message/Call.php
@@ -12,7 +12,6 @@ final class Call
 
     private string $hash;
     private string $objectHash;
-    private string $interface;
 
     private string $method;
 
@@ -22,12 +21,11 @@ final class Call
     /**
      * @param mixed[] $args
      */
-    public function __construct(Channel $channel, string $hash, string $objectHash, string $interface, string $method, array $args)
+    public function __construct(Channel $channel, string $hash, string $objectHash, string $method, array $args)
     {
         $this->channel    = $channel;
         $this->hash       = $hash;
         $this->objectHash = $objectHash;
-        $this->interface  = $interface;
         $this->method     = $method;
         $this->args       = $args;
     }
@@ -45,11 +43,6 @@ final class Call
     public function objectHash(): string
     {
         return $this->objectHash;
-    }
-
-    public function interface(): string
-    {
-        return $this->interface;
     }
 
     public function method(): string

--- a/src/Message/Destruct.php
+++ b/src/Message/Destruct.php
@@ -8,13 +8,11 @@ final class Destruct
 {
     private string $hash;
     private string $objectHash;
-    private string $interface;
 
-    public function __construct(string $hash, string $objectHash, string $interface)
+    public function __construct(string $hash, string $objectHash)
     {
         $this->hash       = $hash;
         $this->objectHash = $objectHash;
-        $this->interface  = $interface;
     }
 
     public function hash(): string
@@ -25,10 +23,5 @@ final class Destruct
     public function objectHash(): string
     {
         return $this->objectHash;
-    }
-
-    public function interface(): string
-    {
-        return $this->interface;
     }
 }

--- a/tests/Message/CallTest.php
+++ b/tests/Message/CallTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ReactParallel\Tests\ObjectProxy\Message;
 
 use parallel\Channel;
-use Psr\Log\LoggerInterface;
 use ReactParallel\ObjectProxy\Message\Call;
 use WyriHaximus\AsyncTestUtilities\AsyncTestCase;
 
@@ -23,16 +22,14 @@ final class CallTest extends AsyncTestCase
         $channel    = new Channel(1);
         $hash       = bin2hex(random_bytes(1024));
         $objectHash = bin2hex(random_bytes(1024));
-        $interface  = LoggerInterface::class;
         $method     = 'hammer';
         $args       = [time()];
 
-        $call = new Call($channel, $hash, $objectHash, $interface, $method, $args);
+        $call = new Call($channel, $hash, $objectHash, $method, $args);
 
         self::assertSame($channel, $call->channel());
         self::assertSame($hash, $call->hash());
         self::assertSame($objectHash, $call->objectHash());
-        self::assertSame($interface, $call->interface());
         self::assertSame($method, $call->method());
         self::assertSame($args, $call->args());
     }


### PR DESCRIPTION
Since we've this information available in the main thread we no longer
need to send this across frm the worker threads anymore.