### PR TITLE
Temporary composer autoload fix

### DIFF
--- a/src/Composer/Installer.php
+++ b/src/Composer/Installer.php
@@ -75,6 +75,22 @@ final class Installer implements PluginInterface, EventSubscriberInterface
         $start    = microtime(true);
         $io       = $event->getIO();
         $composer = $event->getComposer();
+
+        // Composer is bugged and doesn't handle root package autoloading properly yet
+        if (array_key_exists('psr-4', $composer->getPackage()->getAutoload())) {
+            foreach ($composer->getPackage()->getAutoload()['psr-4'] as $ns => $p) {
+                $p = dirname($composer->getConfig()->get('vendor-dir')) . '/' . $p;
+                spl_autoload_register(static function ($class) use ($ns, $p) {
+                    if (strpos($class, $ns) === 0) {
+                        $fileName = $p . str_replace('\\', DIRECTORY_SEPARATOR, substr($class, strlen($ns))) . '.php';
+                        if (file_exists($fileName)) {
+                            include $fileName;
+                        }
+                    }
+                });
+            }
+        }
+
         $rootPath = self::locateRootPackageInstallPath($composer->getConfig(), $composer->getPackage());
 
         if (! function_exists('React\Promise\Resolve')) {


### PR DESCRIPTION
There seems to be a bug in composer that doesn't make the files from the root package available. This temporary fix adds an autoloader to load those files anyway when requested