### PR TITLE
Add thread method to registry

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -19,8 +19,6 @@ use WyriHaximus\Metrics\Label;
 use WyriHaximus\Metrics\Registry\Counters;
 
 use function array_key_exists;
-use function bin2hex;
-use function random_bytes;
 use function serialize;
 use function unserialize;
 
@@ -29,7 +27,6 @@ use const WyriHaximus\Constants\Boolean\TRUE_;
 
 final class Proxy extends ProxyList
 {
-    private const RANDOM_BYTES_LENGTH       = 13;
     private const HASNT_PROXYABLE_INTERFACE = false;
 
     private Factory $factory;
@@ -124,7 +121,7 @@ final class Proxy extends ProxyList
         $in               = new Channel(Channel::Infinite);
         $destruct         = new Channel(Channel::Infinite);
         $this->destruct[] = $destruct;
-        $instance         = new Instance($object, $interface, TRUE_, $in, bin2hex(random_bytes(self::RANDOM_BYTES_LENGTH)));
+        $instance         = $this->registry->thread($object, $interface, $in);
 
         $this->factory->call(
             static function (string $object, string $interface, string $hash, Channel $in, Channel $destruct): void {

--- a/src/Proxy/Registry.php
+++ b/src/Proxy/Registry.php
@@ -8,12 +8,16 @@ use parallel\Channel;
 use ReactParallel\ObjectProxy\Generated\ProxyList;
 
 use function array_key_exists;
+use function bin2hex;
+use function random_bytes;
 
 use const WyriHaximus\Constants\Boolean\FALSE_;
 use const WyriHaximus\Constants\Boolean\TRUE_;
 
 final class Registry extends ProxyList
 {
+    private const RANDOM_BYTES_LENGTH = 13;
+
     private Channel $in;
 
     /** @var array<string, Instance> */
@@ -71,6 +75,15 @@ final class Registry extends ProxyList
     public function share(object $object, string $interface): Instance
     {
         $instance                           = new Instance($object, $interface, TRUE_, $this->in);
+        $this->instances[$instance->hash()] = $instance;
+        $this->shared[$interface]           = $instance->hash();
+
+        return $instance;
+    }
+
+    public function thread(object $object, string $interface, Channel $in): Instance
+    {
+        $instance                           = new Instance($object, $interface, TRUE_, $in, bin2hex(random_bytes(self::RANDOM_BYTES_LENGTH)));
         $this->instances[$instance->hash()] = $instance;
         $this->shared[$interface]           = $instance->hash();
 


### PR DESCRIPTION
By adding this method the threaded object becomes available as shared,
although it's transparent where is runs for anyone using it.