### PR TITLE
Observable support for interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "react/cache": "^1.1.1",
         "react/event-loop": "^1.1",
         "react/promise": "^2.8",
+        "reactivex/rxphp": "^2.0",
         "rx/operator-extras": "^2.1",
         "wyrihaximus/constants": "^1.6",
         "wyrihaximus/iterator-or-array-to-array": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cb86a042ede93b2557f07ea0f45ba79",
+    "content-hash": "39c202fec76561b593e7f2d534840223",
     "packages": [
         {
             "name": "api-clients/rx",

--- a/src/Composer/DeferredInterfaceProxier.php
+++ b/src/Composer/DeferredInterfaceProxier.php
@@ -220,6 +220,9 @@ final class DeferredInterfaceProxier
         if ($this->noPromises && ((string) $method->getReturnType() === 'PromiseInterface' || ($this->parseReturnTypeFromDocBlock($method) !== null && substr((string) $this->parseReturnTypeFromDocBlock($method)->type, 0, 16) === 'PromiseInterface'))) {
             $method->returnType = $this->extractReturnType($method);
         }
+        else if (in_array((string) $method->getReturnType(), ['ObservableInterface', 'Observable']) || ($this->parseReturnTypeFromDocBlock($method) !== null && substr((string) $this->parseReturnTypeFromDocBlock($method)->type, 0, 10) === 'Observable')) {
+            $method->returnType = new Node\Identifier('array');
+        }
 
         return $method;
     }

--- a/src/Composer/InterfaceProxier.php
+++ b/src/Composer/InterfaceProxier.php
@@ -229,6 +229,9 @@ final class InterfaceProxier
         if ($this->noPromises && ((string) $method->getReturnType() === 'PromiseInterface' || ($this->parseReturnTypeFromDocBlock($method) !== null && substr((string) $this->parseReturnTypeFromDocBlock($method)->type, 0, 16) === 'PromiseInterface'))) {
             $method->returnType = $this->extractReturnType($method);
         }
+        else if (in_array((string) $method->getReturnType(), ['ObservableInterface', 'Observable']) || ($this->parseReturnTypeFromDocBlock($method) !== null && substr((string) $this->parseReturnTypeFromDocBlock($method)->type, 0, 10) === 'Observable')) {
+            $method->returnType = new Node\Identifier('array');
+        }
 
         return $method;
     }

--- a/src/Composer/NoPromisesInterfacer.php
+++ b/src/Composer/NoPromisesInterfacer.php
@@ -17,6 +17,7 @@ use function array_key_exists;
 use function count;
 use function current;
 use function implode;
+use function in_array;
 use function is_array;
 use function property_exists;
 use function substr;
@@ -137,6 +138,9 @@ final class NoPromisesInterfacer
          */
         if ((string) $method->getReturnType() === 'PromiseInterface' || ($this->parseReturnTypeFromDocBlock($method) !== null && substr((string) $this->parseReturnTypeFromDocBlock($method)->type, 0, 16) === 'PromiseInterface')) {
             $method->returnType = $this->extractReturnType($method);
+        }
+        else if (in_array((string) $method->getReturnType(), ['ObservableInterface', 'Observable']) || ($this->parseReturnTypeFromDocBlock($method) !== null && substr((string) $this->parseReturnTypeFromDocBlock($method)->type, 0, 10) === 'Observable')) {
+            $method->returnType = new Node\Identifier('array');
         }
 
         return $method;

--- a/src/Proxy/Handler.php
+++ b/src/Proxy/Handler.php
@@ -18,6 +18,7 @@ use ReactParallel\ObjectProxy\Message\Parcel;
 use ReactParallel\ObjectProxy\NonExistentInterface;
 use ReactParallel\Streams\Factory as StreamsFactory;
 use Rx\Observable;
+use Rx\ObservableInterface;
 use WyriHaximus\Metrics\Label;
 use WyriHaximus\Metrics\Registry\Counters;
 
@@ -211,6 +212,10 @@ final class Handler extends ProxyList
                 /** @psalm-suppress PossiblyFalseArgument */
                 $outcome = $this->create($outcome, $this->detectedClasses[$outcomeClass]);
             }
+        }
+
+        if ($outcome instanceof Observable) {
+            $outcome = $outcome->toArray()->toPromise();
         }
 
         if ($outcome instanceof PromiseInterface) {


### PR DESCRIPTION
Just like promises observables should be transformed before tossed back
through the channels.